### PR TITLE
Add VPN without nvidia options, add extra instructions/notes to README, fix small typo in .yaml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gitignore
+.git
 
 # /image
 # .env

--- a/README-fr.md
+++ b/README-fr.md
@@ -18,10 +18,10 @@ Bienvenue dans le dépôt All-jellyfin-media-server ! Ce dépôt contient tout c
 > [!NOTE] 
 > **Access the repository in [English](README.md)**
 
-## **Table des matières :**
+## **Table des matières**
 
 - [**All-jellyfin-media-server**](#all-jellyfin-media-server)
-  - [**Table des matières :**](#table-des-matières-)
+  - [**Table des matières :**](#table-des-matières)
   - [**À quoi sert Isyrr ?**](#à-quoi-sert-isyrr-)
     - [**Jellyfin**](#jellyfin)
     - [**Jellyseerr**](#jellyseerr)
@@ -212,7 +212,7 @@ Pour arrêter la stack :
 docker-compose down
 ```
 
-**[`^        retour au sommaire        ^`](#table-of-contents)**
+**[`^        retour au sommaire        ^`](#table-des-matières)**
 
 ## **NVIDIA**
 
@@ -353,7 +353,7 @@ root@pve:~#nvidia-smi
 +-----------------------------------------------------------------------------+
 ```
 
-**[`^        retour au sommaire        ^`](#table-of-contents)**
+**[`^        retour au sommaire        ^`](#table-des-matières)**
 
 ## **Deuxième méthode**
 
@@ -485,7 +485,7 @@ cd nvidia-patch
 > ```
 > Si des fichiers résiduels restent, recherchez-les en utilisant `apt search nvidia-driver`
 
-**[`^        retour au sommaire        ^`](#table-of-contents)**
+**[`^        retour au sommaire        ^`](#table-des-matières)**
 
 # **VPN**
 
@@ -556,7 +556,7 @@ De mon côté, cela m'affiche une adresse IP en Belgique :
     <img src="image/vpn/vpn4.png" style="margin: 15px 10px;">
 </div>
 
-**[`^        retour au sommaire        ^`](#table-of-contents)**
+**[`^        retour au sommaire        ^`](#table-des-matières)**
 
 ---
 
@@ -638,7 +638,7 @@ docker compose -f docker-compose-<YOUR_VPN>-vpn.yaml up -d
 ```
 [Go to the file here](compose_files/VPN/)
 
-**[`^        retour au sommaire        ^`](#table-of-contents)**
+**[`^        retour au sommaire        ^`](#table-des-matières)**
 
 # **Accéder aux Applications**
 
@@ -709,7 +709,7 @@ Gluetun (Nord VPN) sera automatiquement configuré pour être utilisé avec les 
     <img src="image/qBittorrent/qbit5.png" style="margin: 15px 10px;">
 </div>
 
-**[`^        retour au sommaire        ^`](#table-of-contents)**
+**[`^        retour au sommaire        ^`](#table-des-matières)**
 
 ---
 
@@ -757,7 +757,7 @@ Gluetun (Nord VPN) sera automatiquement configuré pour être utilisé avec les 
     <img src="image/sonarr/son3.png" style="margin: 15px 10px;">
 </div>
 
-**[`^        retour au sommaire        ^`](#table-of-contents)**
+**[`^        retour au sommaire        ^`](#table-des-matières)**
 
 ---
 
@@ -805,7 +805,7 @@ Gluetun (Nord VPN) sera automatiquement configuré pour être utilisé avec les 
     <img src="image/sonarr/son3.png" style="margin: 15px 10px;">
 </div>
 
-**[`^        retour au sommaire        ^`](#table-of-contents)**
+**[`^        retour au sommaire        ^`](#table-des-matières)**
 
 ---
 
@@ -864,7 +864,7 @@ Gluetun (Nord VPN) sera automatiquement configuré pour être utilisé avec les 
     <img src="image/prowlarr/pro3.png" style="margin: 15px 10px;">
 </div>
 
-**[`^        retour au sommaire        ^`](#table-of-contents)**
+**[`^        retour au sommaire        ^`](#table-des-matières)**
 
 ---
 
@@ -906,7 +906,7 @@ Si vous souhaitez que d'autres utilisateurs aient accès à votre serveur Jellyf
 4. Cliquez sur **Sauvegarder** pour créer l'utilisateur.
 5. Répétez ce processus pour tous les utilisateurs que vous souhaitez ajouter au serveur.
 
-**[`^        retour au sommaire        ^`](#table-of-contents)**
+**[`^        retour au sommaire        ^`](#table-des-matières)**
 
 ---
 
@@ -947,7 +947,7 @@ Si vous souhaitez que d'autres utilisateurs aient accès à votre serveur Jellyf
 3. Cliquez sur **Tester** pour vérifier la connexion.
 4. Cliquez sur **Sauvegarder les modifications**.
 
-**[`^        retour au sommaire        ^`](#table-of-contents)**
+**[`^        retour au sommaire        ^`](#table-des-matières)**
 
 ---
 
@@ -962,7 +962,7 @@ docker image prune -a
 
 Ensuite, vous pouvez exécuter `docker-compose up -d` pour redémarrer les conteneurs avec les dernières versions des applications.
 
-**[`^        retour au sommaire        ^`](#table-of-contents)**
+**[`^        retour au sommaire        ^`](#table-des-matières)**
 
 # **Avertissement**
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Welcome to the All-jellyfin-media-server Repository! This repository contains ev
 > [!NOTE] 
 > **Acceder au repository en [Français](README-fr.md)**
 
-## **Table of contents :**
+## **Table of contents**
 
 - [**All-jellyfin-media-server**](#all-jellyfin-media-server)
   - [**Table of contents :**](#table-of-contents-)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Welcome to the All-jellyfin-media-server Repository! This repository contains ev
   - [**1. Basic Installation**](#1-basic-installation)
   - [**2. Installation with NVIDIA Only**](#2-installation-with-nvidia-only)
   - [**3. Installation with NVIDIA and VPN**](#3-installation-with-nvidia-and-vpn)
+  - [**4. Installation with VPN (no NVIDIA)**](#4-installation-with-vpn-no-NVIDIA)
 - [**Accessing Applications**](#accessing-applications)
 - [**Configuration Guide for Web Interfaces Only**](#configuration-guide-for-web-interfaces-only)
   - [**qBittorrent**](#qbittorrent-1)

--- a/README.md
+++ b/README.md
@@ -734,7 +734,10 @@ Gluetun (Nord VPN) will be automatically configured to be used with the applicat
     <img src="image/radarr/rad5.png" style="margin: 15px 10px;">
 </div>
 
-_Note: Radarr may complain that the `/downloads/radarr` directory does not exist inside the container (this is generally flagged as an error by Radarr in  **System** > **Status**). To fix this, simply move into the directory `/COMMON_PATH/qbittorrent/downloads` and manually create the `radarr` directory.
+_Note: if entering `qbittorrent` as the Host does not work, try entering the IP address instead (ex: `192.168.x.x`)_
+
+> [!WARNINGS]
+> Radarr may complain that the `/downloads/radarr` directory does not exist inside the container (this is generally flagged as an error by Radarr in  **System** > **Status**). To fix this, simply move into the directory `/COMMON_PATH/qbittorrent/downloads` and manually create the `radarr` directory.
 
 ### **Indexer Jackett (Optional)**
 
@@ -766,6 +769,8 @@ _Note: Radarr may complain that the `/downloads/radarr` directory does not exist
 <div style="text-align: center">
     <img src="image/sonarr/son1.png" style="margin: 15px 10px;">
 </div>
+
+_Note: if entering `qbittorrent` as the Host does not work, try entering the IP address instead (ex: `192.168.x.x`)_
 
 ### **Download Clients**
 

--- a/README.md
+++ b/README.md
@@ -734,7 +734,7 @@ Gluetun (Nord VPN) will be automatically configured to be used with the applicat
     <img src="image/radarr/rad5.png" style="margin: 15px 10px;">
 </div>
 
-_Note: Radarr may complain that the `/downloads/radarr` directory does not exist inside the container (this is generally flagged as an error by Radarr in  **System** > **Status**). To fix this, simply move into the directory `/COMMON_PATH/qbittorrent/downloads` (using the command `cd /COMMON_PATH/qbittorrent/downloads`) and create the "radarr" directory with this command: `mkdir radarr`_
+_Note: Radarr may complain that the `/downloads/radarr` directory does not exist inside the container (this is generally flagged as an error by Radarr in  **System** > **Status**). To fix this, simply move into the directory `/COMMON_PATH/qbittorrent/downloads` and manually create the `radarr` directory.
 
 ### **Indexer Jackett (Optional)**
 

--- a/README.md
+++ b/README.md
@@ -736,7 +736,7 @@ Gluetun (Nord VPN) will be automatically configured to be used with the applicat
 
 _Note: if entering `qbittorrent` as the Host does not work, try entering the IP address instead (ex: `192.168.x.x`)_
 
-> [!WARNINGS]
+> [!WARNING]
 > Radarr may complain that the `/downloads/radarr` directory does not exist inside the container (this is generally flagged as an error by Radarr in  **System** > **Status**). To fix this, simply move into the directory `/COMMON_PATH/qbittorrent/downloads` and manually create the `radarr` directory.
 
 ### **Indexer Jackett (Optional)**

--- a/README.md
+++ b/README.md
@@ -638,6 +638,7 @@ Once the applications are deployed, you can access them using the following addr
 
 
 * Jellyfin : http://localhost:8096
+* Jellyseer : http://localhost:5055
 * Sonarr : http://localhost:8989
 * Radarr : http://localhost:7878
 * Jackett : http://localhost:9117
@@ -663,7 +664,7 @@ Gluetun (Nord VPN) will be automatically configured to be used with the applicat
     <img src="image/qBittorrent/qbit1.png" style="margin: 15px 10px;">
 </div>
 
-   *Note: The default credentials may have changed, please check the documentation for updates on this.*
+   *Note: The default credentials may have changed, please check the documentation for updates on this. In most cases, qBittorrent Web UI will generate a temporary password when the container is started. To view this password, check the logs for this container with the command: `docker logs qbittorrent`*
 
 1. Once logged in, click the gear icon to go to **Options**.
 2. Under the **Downloads** tab, configure the backup settings as follows:
@@ -732,6 +733,8 @@ Gluetun (Nord VPN) will be automatically configured to be used with the applicat
 <div style="text-align: center">
     <img src="image/radarr/rad5.png" style="margin: 15px 10px;">
 </div>
+
+    *Note: Occasionally, Radarr may complain that the `/downloads/radarr` directory does not exist inside the container (this is generally flagged as an error by Radarr in  **System** > **Status**). To fix this, simply move into the directory `/COMMON_PATH/qbittorrent/downloads` (using the command `cd /COMMON_PATH/qbittorrent/downloads`) and create the "radarr" directory with this command: `mkdir radarr`*
 
 ### **Indexer Jackett (Optional)**
 

--- a/README.md
+++ b/README.md
@@ -615,9 +615,24 @@ docker compose -f docker-compose-nvidia.yaml up -d
 ## **3. Installation with NVIDIA and VPN**
 
 > [!WARNING]  
-> If you use this method, fill in the `.env` file located in `compose_files/VPN`.
+> If you use this method, fill in the `.env` file located in `compose_files/VPN-nvidia`.
 
 Standard installation with both `VPN` and `NVIDIA`:
+
+To start the installation, execute :
+
+```bash
+cd compose_files/VPN-nvidia/
+docker compose -f docker-compose-<YOUR_VPN>-vpn.yaml up -d
+```
+[Go to the file here](compose_files/VPN-nvidia/)
+
+## **4. Installation with VPN (no NVIDIA)**
+
+> [!WARNING]  
+> If you use this method, fill in the `.env` file located in `compose_files/VPN`.
+
+Standard installation with a `VPN`:
 
 To start the installation, execute :
 
@@ -737,7 +752,7 @@ Gluetun (Nord VPN) will be automatically configured to be used with the applicat
 _Note: if entering `qbittorrent` as the Host does not work, try entering the IP address instead (ex: `192.168.x.x`)_
 
 > [!WARNING]
-> Radarr may complain that the `/downloads/radarr` directory does not exist inside the container (this is generally flagged as an error by Radarr in  **System** > **Status**). To fix this, simply move into the directory `/COMMON_PATH/qbittorrent/downloads` and manually create the `radarr` directory.
+> On new installations, Radarr may complain that the `/downloads/radarr` directory does not exist inside the container (this is generally flagged as an error by Radarr in  **System** > **Status**). To fix this, simply move into the directory `/COMMON_PATH/qbittorrent/downloads` and manually create the `radarr` directory. Then, simply delete qBittorrent from Radarr and re-add it -  you should see the error disappear.
 
 ### **Indexer Jackett (Optional)**
 

--- a/README.md
+++ b/README.md
@@ -734,7 +734,7 @@ Gluetun (Nord VPN) will be automatically configured to be used with the applicat
     <img src="image/radarr/rad5.png" style="margin: 15px 10px;">
 </div>
 
-    *Note: Occasionally, Radarr may complain that the `/downloads/radarr` directory does not exist inside the container (this is generally flagged as an error by Radarr in  **System** > **Status**). To fix this, simply move into the directory `/COMMON_PATH/qbittorrent/downloads` (using the command `cd /COMMON_PATH/qbittorrent/downloads`) and create the "radarr" directory with this command: `mkdir radarr`*
+_Note: Radarr may complain that the `/downloads/radarr` directory does not exist inside the container (this is generally flagged as an error by Radarr in  **System** > **Status**). To fix this, simply move into the directory `/COMMON_PATH/qbittorrent/downloads` (using the command `cd /COMMON_PATH/qbittorrent/downloads`) and create the "radarr" directory with this command: `mkdir radarr`_
 
 ### **Indexer Jackett (Optional)**
 

--- a/compose_files/.env
+++ b/compose_files/.env
@@ -1,18 +1,3 @@
 # BASE
 COMMON_PATH=/YOUR_PATH/Isyrr
 TZ=Europe/Paris
-
-# Uncomment the lines below to enable the corresponding VPN configuration
-
-# NORD VPN
-# OPENVPN_USER=username  # Your username for NordVPN
-# OPENVPN_PASSWORD=password  # Your password for NordVPN
-# SERVER_REGIONS=Belgium  # Choose the server region (Belgium here)
-
-# PROTON VPN 
-# ENDPOINT_IP=PEER_ENDPOINT_IP  # The endpoint IP address of the VPN server
-# WIREGUARD_ADDR=Interface_Address  # The WireGuard interface address
-# ENDPOINT_PORT=51820  # Default port is 51820, but confirm if different
-# DNS_ADDRESS=Interface_DNS  # DNS address for ProtonVPN
-# PUBLIC_KEY=PEER_PublicKey  # The public key of the other peer
-# PRIVATE_KEY=Interface_PrivateKey  # Your private key

--- a/compose_files/VPN-nvidia/.env
+++ b/compose_files/VPN-nvidia/.env
@@ -1,0 +1,18 @@
+# BASE
+COMMON_PATH=/YOUR_PATH/Isyrr
+TZ=Europe/Paris
+
+# Uncomment the lines below to enable the corresponding VPN configuration
+
+# NORD VPN
+# OPENVPN_USER=username  # Your username for NordVPN
+# OPENVPN_PASSWORD=password  # Your password for NordVPN
+# SERVER_REGIONS=Belgium  # Choose the server region (Belgium here)
+
+# PROTON VPN 
+# ENDPOINT_IP=PEER_ENDPOINT_IP  # The endpoint IP address of the VPN server
+# WIREGUARD_ADDR=Interface_Address  # The WireGuard interface address
+# ENDPOINT_PORT=51820  # Default port is 51820, but confirm if different
+# DNS_ADDRESS=Interface_DNS  # DNS address for ProtonVPN
+# PUBLIC_KEY=PEER_PublicKey  # The public key of the other peer
+# PRIVATE_KEY=Interface_PrivateKey  # Your private key

--- a/compose_files/VPN-nvidia/docker-compose-nord-vpn.yaml
+++ b/compose_files/VPN-nvidia/docker-compose-nord-vpn.yaml
@@ -122,6 +122,14 @@ services:
       - ${COMMON_PATH}/radarr/movies:/data/movies
       - ${COMMON_PATH}/qbittorrent/downloads:/data/media_downloads
     restart: unless-stopped
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities:
+                - gpu
   jellyseerr:
     image: fallenbagel/jellyseerr:latest
     container_name: jellyseerr

--- a/compose_files/VPN-nvidia/docker-compose-proton-vpn.yaml
+++ b/compose_files/VPN-nvidia/docker-compose-proton-vpn.yaml
@@ -1,28 +1,41 @@
 ---
 version: "3.3"
 services:
-  nordvpn:
+  gluetun:
     container_name: GlueTun-VPN
     image: qmcgaw/gluetun
     cap_add:
       - NET_ADMIN
     ports:
       - 8080:8080
-      - 51420:51420
-      - 51420:51420/udp
+      - 51820:51820
+      - 51820:51820/udp
+      - 46931:46931
+      - 46931:46931/udp
     environment:
-      - VPN_SERVICE_PROVIDER=nordvpn
-      - OPENVPN_USER=${OPENVPN_USER}
-      - OPENVPN_PASSWORD=${OPENVPN_PASSWORD}
-      - SERVER_REGIONS=${SERVER_REGIONS}
-      - VPN_TYPE=openvpn
+      - VPN_SERVICE_PROVIDER=custom
+      - VPN_TYPE=wireguard
+      - VPN_ENDPOINT_IP=${ENDPOINT_IP}
+      - WIREGUARD_ADDRESSES=${WIREGUARD_ADDR}
+      - VPN_ENDPOINT_PORT=${ENDPOINT_PORT}
+      - VPN_DNS_ADDRESS=${DNS_ADDRESS}
+      - WIREGUARD_PUBLIC_KEY=${PUBLIC_KEY}
+      - WIREGUARD_PRIVATE_KEY=${PRIVATE_KEY}
+      - VPN_PORT_FORWARDING=on
+      - VPN_PORT_FORWARDING_PROVIDER=protonvpn
+      - VPN_PORT_FORWARDING_STATUS_FILE=/tmp/gluetun/forwarded_port
+      - TZ=${TZ}
+      - UPDATER_PERIOD=24h
     restart: always
+    volumes:
+      - ${COMMON_PATH}:${COMMON_PATH}
+      - ${COMMON_PATH}/gluetun:/tmp/gluetun
   qbittorrent:
     image: lscr.io/linuxserver/qbittorrent:latest
-    network_mode: service:nordvpn
+    network_mode: service:gluetun
     container_name: qbittorrent
     depends_on:
-      - nordvpn
+      - gluetun
     environment:
       - WEBUI_PORT=8080
       - PUID=0
@@ -122,6 +135,14 @@ services:
       - ${COMMON_PATH}/radarr/movies:/data/movies
       - ${COMMON_PATH}/qbittorrent/downloads:/data/media_downloads
     restart: unless-stopped
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities:
+                - gpu
   jellyseerr:
     image: fallenbagel/jellyseerr:latest
     container_name: jellyseerr

--- a/compose_files/VPN/docker-compose-proton-vpn.yaml
+++ b/compose_files/VPN/docker-compose-proton-vpn.yaml
@@ -135,14 +135,6 @@ services:
       - ${COMMON_PATH}/radarr/movies:/data/movies
       - ${COMMON_PATH}/qbittorrent/downloads:/data/media_downloads
     restart: unless-stopped
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities:
-                - gpu
   jellyseerr:
     image: fallenbagel/jellyseerr:latest
     container_name: jellyseerr


### PR DESCRIPTION
- Added a "VPN-nvidia" folder for VPN & NVIDIA setups, and modified the "VPN" compose files to work without NVIDIA.
- Updated the README to reflect changes made above (added instructions for VPN w/out NVIDIA setup) 

- Fixed a small typo in the Docker Compose (.yaml) files where NordVPN  `SERVER_REGIONS` would always get set to Belgium
- Removed VPN configuration from `.env` file for the the no VPN Docker Compose (.yaml) files  

- Added Jellyseer to the list of accessible applications in README

